### PR TITLE
Some fixes and a little bit of refactoring

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,7 +7,7 @@
             <span>Powered by <a href="https://gohugo.io/">Hugo</a>.</span>
             <span>
               {{ if .Site.Copyright }}
-              {{ .Site.Copyright }}
+              {{ .Site.Copyright | markdownify}}
               {{ else }}
               Copyright (c) {{ .Site.LastChange.Format "2006" }}, <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
               {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,13 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     {{ .Hugo.Generator }}
     <link rel="shortcut icon" href="/images/favicon.ico">
-    {{ if .RSSlink }}
-    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-    <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
-    {{ else }}
-    <link href="/index.xml" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-    <link href="/index.xml" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
-    {{ end }}
+    <link href="{{ or .RSSLink .Site.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <!-- font awesome -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,6 +14,22 @@
     <link rel="stylesheet" href="https://yandex.st/highlightjs/8.0/styles/default.min.css">
     <script src="https://yandex.st/highlightjs/8.0/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
+    {{ if .Site.Params.mathjax }}
+    <script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+      tex2jax: {
+        inlineMath: [['$','$'], ['\\(','\\)']],
+        displayMath: [['$$','$$'], ['\[','\]']],
+        processEscapes: true,
+        processEnvironments: true,
+        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+        TeX: { equationNumbers: { autoNumber: "AMS" },
+             extensions: ["AMSmath.js", "AMSsymbols.js"] }
+      }
+    });
+    </script>
+    <script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+    {{ end }}
     <link rel="stylesheet" type="text/css" href="{{ "/css/style.css" | relURL }}">
     <title>{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
   </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="https://yandex.st/highlightjs/8.0/styles/default.min.css">
     <script src="https://yandex.st/highlightjs/8.0/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    <link rel="stylesheet" type="text/css" href="/css/style.css">
+	<link rel="stylesheet" type="text/css" href="{{ "/css/style.css" | relURL }}">
     <title>{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
   </head>
   <body>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,6 +2,7 @@
 <html lang="{{ .Site.LanguageCode }}">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     {{ .Hugo.Generator }}
     <link rel="shortcut icon" href="/images/favicon.ico">
     {{ if .RSSlink }}
@@ -11,7 +12,6 @@
     <link href="/index.xml" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     <link href="/index.xml" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{ end }}
-    <meta name="viewport" content="width=device-width,initial-scale=1">
     <!-- font awesome -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">
     <!-- google_analytics -->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     {{ .Hugo.Generator }}
-    <link rel="shortcut icon" href="/images/favicon.ico">
+    <link rel="shortcut icon" href="{{ "/images/favicon.ico" | relURL }}">
     <link href="{{ or .RSSLink .Site.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     <!-- font awesome -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="https://yandex.st/highlightjs/8.0/styles/default.min.css">
     <script src="https://yandex.st/highlightjs/8.0/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-	<link rel="stylesheet" type="text/css" href="{{ "/css/style.css" | relURL }}">
+    <link rel="stylesheet" type="text/css" href="{{ "/css/style.css" | relURL }}">
     <title>{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
   </head>
   <body>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -39,7 +39,7 @@
       <ul>
         {{ range $category, $taxonomy := . }}
         <li>
-          <a href="/categories/{{ $category | urlize }}"><span></span>{{ $category }} ({{ $taxonomy.Count }})</a>
+          <a href="{{ "/categories/" | relURL }}{{ $category | urlize }}"><span></span>{{ $category }} ({{ $taxonomy.Count }})</a>
         </li>
         {{ end }}
       </ul>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -51,7 +51,7 @@
       <span>RSS</span>
     </div>
     <div id="rss">
-      <a href="{{ if .RSSlink }}{{ .RSSlink }}{{ else }}/index.xml{{ end }}" type="application/rss+xml" target="_blank">
+      <a href="{{ or .RSSLink .Site.RSSLink }}" type="application/rss+xml" target="_blank">
         <i class="fa fa-rss-square fa-2x" aria-hidden="true"></i>
       </a>
     </div>

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -3,7 +3,7 @@
   <ul>
     {{ range .Params.tags }}
     <li>
-      <a href="/tags/{{ . | urlize }}"><span></span>{{ . }}</a>
+        <a href="/tags/{{ . | urlize }}">{{ . }}</a>
     </li>
     {{ end }}
   </ul>

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -3,7 +3,7 @@
   <ul>
     {{ range .Params.tags }}
     <li>
-        <a href="/tags/{{ . | urlize }}">{{ . }}</a>
+        <a href="{{ "/tags/" | relURL }}{{ . | urlize }}">{{ . }}</a>
     </li>
     {{ end }}
   </ul>


### PR DESCRIPTION
I used the template function [relURL](https://gohugo.io/templates/functions/#absurl-relurl) to make the link to the CSS stylesheet aware of the configured baseURL. Without this the browser cannot find the stylesheet when `baseurl` is set to a subdirectory of a server, i.e. `baseurl = "http://example.com/hugo/"`.
