### PR TITLE
header.html: shorten code to link to rss feed

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,13 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     {{ .Hugo.Generator }}
     <link rel="shortcut icon" href="/images/favicon.ico">
-    {{ if .RSSlink }}
-    <link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-    <link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
-    {{ else }}
-    <link href="/index.xml" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-    <link href="/index.xml" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
-    {{ end }}
+    <link href="{{ or .RSSLink .Site.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <!-- font awesome -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">


### PR DESCRIPTION
By using `{{ or .RSSLink .Site.RSSLink}}` the code for linking to the RSS feed can be shorten. Note that `.SiteRSSLink` should be used instead of `"/index.html"` since `baseurl` might be a subdirectory of a server. Concerning https://www.w3.org/wiki/HTML/Elements/link and https://www.w3.org/TR/html5/links.html the code `rel="feed"` is not supported in HTML5 anymore. `rel="alternate"` should be sufficient (I guess)...
